### PR TITLE
Do not respond to ack with a ack messageType

### DIFF
--- a/src/mozilla.org/simplepush/worker.go
+++ b/src/mozilla.org/simplepush/worker.go
@@ -249,9 +249,6 @@ func (self *Worker) Ack(sock PushWS, buffer interface{}) (err error) {
 	err = sock.Store.Ack(sock.Uaid, data)
 	// Get the lastAccessed time from wherever.
 	if err == nil {
-		websocket.JSON.Send(sock.Socket, util.JsMap{
-			"messageType": data["messageType"],
-			"status":      200})
 		self.Flush(sock, 0)
 		return nil
 	}


### PR DESCRIPTION
The client does not expect a reply. Even if the client ack is lost before it is processed by the server, and the server sends it again, that is fine, since the client will try to respond again with an ack, but won't wake up the application, since the version hasn't changed.
