### PR TITLE
Fix tests bug in handling tokenized endpoints and fix test_notify

### DIFF
--- a/mod_test/pushtest/pushTestCase.py
+++ b/mod_test/pushtest/pushTestCase.py
@@ -46,7 +46,7 @@ class PushTestCase(unittest.TestCase):
                 print 'Unable to parse json:', e
                 raise AssertionError, e
 
-    def compare_dict(self, ret_data, exp_data):
+    def compare_dict(self, ret_data, exp_data, exit_on_assert=False):
         """ compares two dictionaries and raises assert with info """
         self.log("RESPONSE GOT:", ret_data)
         self.log("RESPONSE EXPECTED:", exp_data)
@@ -55,6 +55,8 @@ class PushTestCase(unittest.TestCase):
 
         if diff["errors"]:
             print 'AssertionError', diff["errors"]
+            if exit_on_assert:
+                exit("AssertionError: %s" % diff["errors"])
             raise AssertionError, diff["errors"]
 
     def validate_endpoint(self, endpoint):

--- a/mod_test/pushtest/utils.py
+++ b/mod_test/pushtest/utils.py
@@ -14,16 +14,20 @@ def get_uaid(chan_str):
     """uniquify our channels so there's no collision"""
     return "%s%s" % (chan_str, str_gen(16))
 
-def send_http_put(update_path, args='version=123'):
+def send_http_put(update_path, args='version=123', ct='application/x-www-form-urlencoded', exit_on_assert=False):
     """ executes an HTTP PUT with version"""
-    print_log('update_path', update_path)
+    print_log('send_http_put', update_path)
     opener = urllib2.build_opener(urllib2.HTTPHandler)
-    request = urllib2.Request(update_path, data=args)
+    request = urllib2.Request(update_path, args)
+    request.add_header('Content-Type', ct)
     request.get_method = lambda: 'PUT'
     try:
         url = opener.open(request)
-    except HTTPError, (errno, msg):
-        raise
+    except Exception, e:
+        if exit_on_assert:
+            exit('Exception in HTTP PUT: %s' % e)
+        raise Exception, e
+
     url.close()
     return url.getcode()
 


### PR DESCRIPTION
All tests pass with local master build and AWS dev and prod.  Tests not working with secure web sockets.
test_notify tests one uaid with two different channels, updating version numbers and ack of those channels.
